### PR TITLE
Add MCP Server Bearer Token Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,22 @@ const getNumberFact = tool({
 This tool will basically fetch the `numbersapi.com` and give a random fact about a number. Of course that is something the chat agent with OpenAI as LLM in the background can also do, but this way you don't eat up for credits and it is just a way to outline how to add a tool to the agent. 
 
 ## 2 MCP Server
-In order to give your agent more capabilities you can add an MCP server to the agent. You can connect to an existing MCP server or create your own using muppet: 
-- [This list](https://mcp.composio.dev/) inculdes some existing MCP servers ready to use. 
+In order to give your agent more capabilities you can add an MCP server to the agent. You can connect to an existing MCP server or create your own using muppet:
+- [This list](https://mcp.composio.dev/) inculdes some existing MCP servers ready to use.
 - Use [muppet.io](https://www.muppet.dev/docs) to create your own MCP server
-- Here is an [example repo](https://github.com/muppet-dev/muppet/tree/main/examples) of a MCP server using muppet. 
+- Here is an [example repo](https://github.com/muppet-dev/muppet/tree/main/examples) of a MCP server using muppet.
 
-Simply chat to your agent and let it now you like to add an MCP server to it and provide it with the URL of the MCP server. 
+Simply chat to your agent and let it now you like to add an MCP server to it and provide it with the URL of the MCP server.
+
+### Authentication Options
+
+The agent supports two methods for authenticating with MCP servers:
+
+1. **OAuth Flow (Default)**: When you provide just the MCP server URL, the agent will initiate an OAuth authentication flow.
+
+2. **Bearer Token**: If your MCP server requires bearer token authentication, you can provide both the URL and the token directly in the chat. This is useful for servers that don't support OAuth or when you prefer direct authentication.
+
+Example: "Please add the MCP server at https://example.com/mcp with bearer token abc123xyz456"
 
 Once the MCP server is added you can see it in Fiberplane's agent playground.
 <img src="img/mcp-added.png" width="300" alt="mcp-added">

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ai-sdk/openai": "^1.3.9",
         "@ai-sdk/react": "^1.2.8",
         "@ai-sdk/ui-utils": "^1.2.7",
-        "@fiberplane/agents": "^0.4.0-canary.1",
+        "@fiberplane/agents": "0.4.1",
         "@phosphor-icons/react": "^2.1.7",
         "@radix-ui/react-avatar": "^1.1.4",
         "@radix-ui/react-dropdown-menu": "^2.1.7",
@@ -2239,9 +2239,9 @@
       }
     },
     "node_modules/@fiberplane/agents": {
-      "version": "0.4.0-canary.1",
-      "resolved": "https://registry.npmjs.org/@fiberplane/agents/-/agents-0.4.0-canary.1.tgz",
-      "integrity": "sha512-+9EBQmRTR2exxf8wv9QkTLTwID9/KLjj5m985TNNlRf//iRUK9x5lPdrSzC9Rq6gyR79VDgwmhuJmaK+vQWJ8A==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@fiberplane/agents/-/agents-0.4.1.tgz",
+      "integrity": "sha512-5i8aAwpcTP9sZjypsmwR8vlAIVXu+Te1MuT4WjqTl8tUayhzO2DD/YLYM+8lpCoJFpupoUoegKDvVSWwVYCDGA==",
       "license": "MIT/Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^1.13.7",
@@ -2249,6 +2249,7 @@
         "agents": "^0.0.50",
         "ai": "^4.1.61",
         "chokidar": "^3.6.0",
+        "cloudflare": "^4.2.0",
         "clsx": "^2.1.1",
         "hono": "^4.7.4",
         "jsonc-parser": "^3.3.1",
@@ -4186,10 +4187,19 @@
       "version": "22.14.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.0.tgz",
       "integrity": "sha512-Kmpl+z84ILoG+3T/zQFyAJsU6EPTmOCj8/2+83fSN6djd6I4o7uOuGIH6vq3PrjY5BGitSbFuMN18j3iknubbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/react": {
@@ -4386,6 +4396,18 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -4439,6 +4461,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/agents": {
@@ -4553,6 +4587,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
     },
     "node_modules/bail": {
       "version": "2.0.2",
@@ -4870,6 +4910,36 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/cloudflare": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/cloudflare/-/cloudflare-4.2.0.tgz",
+      "integrity": "sha512-L9IainZq+7PN3NG/Mg7T9oRm7SB7AskNe6QLD8j7FrJY+2Dn1qpeLqXF8Im04ANnssezf0KAOtSuxNAAyNEgkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/cloudflare/node_modules/@types/node": {
+      "version": "18.19.86",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.86.tgz",
+      "integrity": "sha512-fifKayi175wLyKyc5qUfyENhQ1dCNI1UNjp653d8kuYcPQN5JhX3dGuP/XmvPTg/xRBn1VTLpbmi+H/Mr7tLfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/cloudflare/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -4922,6 +4992,18 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/comma-separated-tokens": {
@@ -5082,6 +5164,15 @@
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
       "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -5297,6 +5388,21 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.25.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
@@ -5388,6 +5494,15 @@
       "resolved": "https://registry.npmjs.org/event-target-polyfill/-/event-target-polyfill-0.0.4.tgz",
       "integrity": "sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==",
       "license": "MIT"
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/eventsource": {
       "version": "3.0.6",
@@ -5589,6 +5704,40 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
+      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
+      "license": "MIT"
+    },
+    "node_modules/formdata-node": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
+      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.3"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -5768,6 +5917,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -5888,6 +6052,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -7133,6 +7306,46 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-fetch-native": {
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.6.tgz",
@@ -8275,6 +8488,12 @@
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
       "license": "MIT"
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -8372,7 +8591,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unenv": {
@@ -8774,6 +8992,31 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
+      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@ai-sdk/openai": "^1.3.9",
     "@ai-sdk/react": "^1.2.8",
     "@ai-sdk/ui-utils": "^1.2.7",
-    "@fiberplane/agents": "^0.4.0-canary.1",
+    "@fiberplane/agents": "0.4.1",
     "@phosphor-icons/react": "^2.1.7",
     "@radix-ui/react-avatar": "^1.1.4",
     "@radix-ui/react-dropdown-menu": "^2.1.7",

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,7 @@ import { MCPClientManager } from "agents/mcp/client";
 export type Env = {
   OPENAI_API_KEY: string;
   RESEND_API_KEY: string;
+  HOST: string;
   Chat: AgentNamespace<Chat>;
 };
 
@@ -62,7 +63,34 @@ export class Chat extends AIChatAgent<Env, MemoryState> {
     });
   }
 
-  async addMcpServer(url: string) {
+  async addMcpServer(url: string, bearerToken?: string) {
+    // If a bearer token is provided, use it for bearer token auth
+    if (bearerToken) {
+      try {
+        // For the bearer token approach, we need to create a direct connection
+        // to the MCP server without going through the OAuth flow.
+        // First, we'll connect to get an ID
+        const { id } = await this.mcp.connect(url);
+        
+        // Store the bearer token in the agent's memory for use with this MCP server
+        const memories = this.state.memories || {};
+        memories[`mcp_token_${id}`] = {
+          value: bearerToken,
+          timestamp: new Date().toISOString(),
+        };
+        
+        // Update the state
+        await this.setState({ memories });
+        
+        console.log(`Added MCP server with ID: ${id} and stored bearer token`);
+        return "MCP server connected successfully using bearer token";
+      } catch (error: any) {
+        console.error("Error connecting with bearer token:", error);
+        return `Error connecting to MCP server: ${error.message}`;
+      }
+    }
+    
+    // Otherwise, fall back to OAuth flow
     const { id, authUrl } = await this.mcp.connect(url);
     console.log(`Added MCP server with ID: ${id}`);
     return authUrl ?? "";
@@ -77,6 +105,41 @@ export class Chat extends AIChatAgent<Env, MemoryState> {
   }
 
   async onRequest(request: Request) {
+    // Check if this is an MCP request that needs a token
+    if (request.url.includes('/mcp/')) {
+      // Extract the server ID from the URL
+      const urlParts = new URL(request.url);
+      const pathParts = urlParts.pathname.split('/');
+      const mcpServerIdIndex = pathParts.indexOf('mcp') + 1;
+      
+      if (mcpServerIdIndex > 0 && mcpServerIdIndex < pathParts.length) {
+        const serverId = pathParts[mcpServerIdIndex];
+        
+        // Check if we have a bearer token for this server
+        const memories = this.state.memories || {};
+        const tokenMemory = memories[`mcp_token_${serverId}`];
+        
+        if (tokenMemory) {
+          // Clone the request and add the bearer token
+          const headers = new Headers(request.headers);
+          headers.set('Authorization', `Bearer ${tokenMemory.value}`);
+          
+          const newRequest = new Request(request.url, {
+            method: request.method,
+            headers,
+            body: request.body,
+            redirect: request.redirect,
+          });
+          
+          console.log(`Added bearer token to request for MCP server ${serverId}`);
+          
+          // Continue with the modified request
+          request = newRequest;
+        }
+      }
+    }
+    
+    // Handle MCP callback requests
     if (this.mcp.isCallbackRequest(request)) {
       const { serverId } = await this.mcp.handleCallbackRequest(request);
 
@@ -133,6 +196,13 @@ You can send emails on behalf of the user using the 'sendEmail' tool:
 - Required information: recipient email address, subject, recipient's first name, and the email message
 - Be professional and clear in your email communications
 - Always confirm with the user before sending an email
+
+# MCP Server Integration
+You can connect to external MCP servers to access additional capabilities:
+- When a user asks to register an MCP server, use the mcpServerTool
+- You can connect using either OAuth authentication (automatic) or bearer token authentication
+- For bearer token authentication, ask the user to provide their bearer token and include it as the bearerToken parameter
+- Example: "To add an MCP server with a bearer token, please provide the server URL and your bearer token"
 
 Example: If a user says "Send an email to john@example.com about our meeting tomorrow", ask for any missing details, then use the sendEmail tool.
 `,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -284,13 +284,17 @@ export const mcpServerTool = tool({
       .min(1)
       .url()
       .describe("The full URL of the remote MCP server"),
+    bearerToken: z
+      .string()
+      .optional()
+      .describe("Optional bearer token for authentication"),
   }),
-  execute: async ({ url }) => {
+  execute: async ({ url, bearerToken }) => {
     const agent = agentContext.getStore();
     if (!agent) {
       throw new Error("Agent not found");
     }
-    return agent.addMcpServer(url);
+    return agent.addMcpServer(url, bearerToken);
   },
 });
 


### PR DESCRIPTION
This PR adds support for bearer token authentication when connecting to MCP servers from within the chat agent.

## Changes:

- Enhanced the `mcpServerTool` to accept an optional `bearerToken` parameter
- Implemented token storage in the agent's memory for persistent authentication 
- Added request interception to automatically attach bearer tokens to MCP server requests
- Updated the AI system message with instructions for handling bearer token authentication
- Added documentation for the new authentication option in the README

## Usage:

Users can now directly provide bearer tokens in chat conversations:

```
"Please add the MCP server at https://example.com/mcp with bearer token abc123xyz456"
```

This feature provides a more flexible authentication mechanism for MCP servers that don't support OAuth or when direct authentication is preferred.
